### PR TITLE
Add CI/CD with GitHub actions

### DIFF
--- a/.github/workflows/macos-workflow.yml
+++ b/.github/workflows/macos-workflow.yml
@@ -63,4 +63,18 @@ jobs:
 
       - name: Build PCSX2
         working-directory: ./build
-        run: make -j2 # macOS doesn't use make install
+        run: make -j$(getconf _NPROCESSORS_ONLN) # macOS doesn't use make install
+    
+      - name: Compress pcsx2 folder
+        working-directory: ./build/pcsx2
+        run: |
+          tar -zcvf pcsx2.tar.gz PCSX2.app
+    
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pcsx2-${{ steps.slug.outputs.sha8 }}-${{matrix.os}}
+          path: build/pcsx2/pcsx2.tar.gz


### PR DESCRIPTION
## Description

This PR will help you to autogenerate the binaries for the macOS implementation.
Using GitHub actions you will have automatically over there the `PCSX2` MacOs app, just ready to use it.

Thanks