### PR TITLE
gcc compatibility for older distros

### DIFF
--- a/.github/workflows/scripts/linux/appimage.sh
+++ b/.github/workflows/scripts/linux/appimage.sh
@@ -53,8 +53,8 @@ cp "$GITHUB_WORKSPACE"/bin/docs/{Configuration_Guide.pdf,PCSX2_FAQ.pdf} "$GITHUB
 cp "$GITHUB_WORKSPACE"/bin/cheats_ws.zip "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/app
 cp ./bin/GameIndex.yaml "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/app/GameIndex.yaml
 cp /usr/lib/$LIBARCH/libthai.so.0 "$GITHUB_WORKSPACE"/squashfs-root/usr/lib/
-cp --dereference /usr/lib/$LIBARCH/libstdc++.so.6 "$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libstdc++/libstdc++.so.6
-cp --dereference /lib/$LIBARCH/libgcc_s.so.1"$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libgcc_s/libgcc_s.so.1
+cp --dereference /usr/lib/"$LIBARCH"/libstdc++.so.6 "$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libstdc++/libstdc++.so.6
+cp --dereference /lib/"$LIBARCH"/libgcc_s.so.1 "$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libgcc_s/libgcc_s.so.1
 export UPD_INFO="gh-releases-zsync|PCSX2|pcsx2|latest|$name.AppImage.zsync"
 export OUTPUT="$name.AppImage"
 /tmp/squashfs-root/AppRun --appdir="$GITHUB_WORKSPACE"/squashfs-root/ --plugin gtk -d "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.desktop -i "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.png --output appimage

--- a/.github/workflows/scripts/linux/appimage.sh
+++ b/.github/workflows/scripts/linux/appimage.sh
@@ -37,11 +37,15 @@ mkdir -p squashfs-root/usr/share/icons && cp ./squashfs-root/PCSX2.png ./squashf
 mkdir -p squashfs-root/usr/share/icons/hicolor/scalable/apps && cp ./squashfs-root/PCSX2.png ./squashfs-root/usr/share/icons/hicolor/scalable/apps
 mkdir -p squashfs-root/usr/share/pixmaps && cp ./squashfs-root/PCSX2.png ./squashfs-root/usr/share/pixmaps
 mkdir -p squashfs-root/usr/lib/
+mkdir -p squashfs-root/usr/optional/libstdc++
+mkdir -p squashfs-root/usr/optional/libgcc_s
 cp ./.github/workflows/scripts/linux/AppRun "$GITHUB_WORKSPACE"/squashfs-root/AppRun
-curl -sSfL "https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-$APPARCH" -o "$GITHUB_WORKSPACE"/squashfs-root/AppRun-patched
+curl -sSfL "https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-$APPARCH" -o "$GITHUB_WORKSPACE"/squashfs-root/AppRun-patched
+curl -sSfL "https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-$APPARCH.so" -o "$GITHUB_WORKSPACE"/squashfs-root/usr/optional/exec.so
 chmod a+x ./squashfs-root/AppRun
 chmod a+x ./squashfs-root/runtime
 chmod a+x ./squashfs-root/AppRun-patched
+chmod a+x ./squashfs-root/usr/optional/exec.so
 echo "$name" > "$GITHUB_WORKSPACE"/squashfs-root/version.txt
 mkdir -p "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/app
 cp -r "$GITHUB_WORKSPACE"/bin/Langs "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/
@@ -49,6 +53,8 @@ cp "$GITHUB_WORKSPACE"/bin/docs/{Configuration_Guide.pdf,PCSX2_FAQ.pdf} "$GITHUB
 cp "$GITHUB_WORKSPACE"/bin/cheats_ws.zip "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/app
 cp ./bin/GameIndex.yaml "$GITHUB_WORKSPACE"/squashfs-root/usr/bin/app/GameIndex.yaml
 cp /usr/lib/$LIBARCH/libthai.so.0 "$GITHUB_WORKSPACE"/squashfs-root/usr/lib/
+cp --dereference /usr/lib/$LIBARCH/libstdc++.so.6 "$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libstdc++/libstdc++.so.6
+cp --dereference /lib/$LIBARCH/libgcc_s.so.1"$GITHUB_WORKSPACE"/squashfs-root/usr/optional/libgcc_s/libgcc_s.so.1
 export UPD_INFO="gh-releases-zsync|PCSX2|pcsx2|latest|$name.AppImage.zsync"
 export OUTPUT="$name.AppImage"
 /tmp/squashfs-root/AppRun --appdir="$GITHUB_WORKSPACE"/squashfs-root/ --plugin gtk -d "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.desktop -i "$GITHUB_WORKSPACE"/squashfs-root/PCSX2.png --output appimage

--- a/.github/workflows/scripts/linux/generate-cmake.sh
+++ b/.github/workflows/scripts/linux/generate-cmake.sh
@@ -3,8 +3,8 @@
 set -e
 
 if [ "${COMPILER}" = "gcc" ]; then
-  export CC=gcc-8
-  export CXX=g++-8
+  export CC=gcc-10
+  export CXX=g++-10
 else
   export CC=clang
   export CXX=clang++

--- a/.github/workflows/scripts/linux/install-packages.sh
+++ b/.github/workflows/scripts/linux/install-packages.sh
@@ -36,10 +36,10 @@ declare -a PCSX2_PACKAGES=(
 )
 
 if [ "${COMPILER}" = "gcc" ]; then
-  BUILD_PACKAGES+=("g++-8-multilib")
+  BUILD_PACKAGES+=("g++-10-multilib")
 else
   BUILD_PACKAGES+=("clang")
-  PCSX2_PACKAGES+=("libstdc++-8-dev")
+  PCSX2_PACKAGES+=("libstdc++-10-dev")
 fi
 
 # - https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md


### PR DESCRIPTION
Add compatibility layer for using newer gcc on older distros.
- use AppImageKit-checkrt
- copy build system stdc++ and gcc_s

### Description of Changes
<!-- Brief description or overview on what was changed in the PR -->
change appimage runtime to use a patched version
this version checks the system gcc version and selects to use system or pacakged

### Rationale behind Changes
<!-- Why were these changes made?  What problem does it solve / area does it improve? -->
appimage will fail to run on older systems with an incompatible gcc build version

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
